### PR TITLE
Rename custom identifiers

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -42,7 +42,8 @@
     "postcss": "6.0.17",
     "postcss-discard-duplicates": "2.1.0",
     "postcss-js": "1.0.1",
-    "postcss-nest-atrules": "0.1.3"
+    "postcss-nest-atrules": "0.1.3",
+    "postcss-reduce-idents": "^4.0.1"
   },
   "devDependencies": {
     "browserify": "^16.1.1",

--- a/compiler/src/index.js
+++ b/compiler/src/index.js
@@ -36,7 +36,7 @@ const createDss = (singleton = false) => async (css, options = {}) => {
   }
 
   const sheetId = String(singleton ? 0 : uuid++)
-  const result = await processor(css, { from: opts.filePath })
+  const result = await processor(css, { from: opts.filePath }, sheetId)
   const locals = compile(objectify(result.root), {
     makeReadableClass,
     sheetId,

--- a/compiler/src/plugins/reduce-idents.js
+++ b/compiler/src/plugins/reduce-idents.js
@@ -1,0 +1,6 @@
+const reduceIdentsPlugin = require('postcss-reduce-idents')
+const hash = require('../vendor/hash')
+
+module.exports = sheetId => reduceIdentsPlugin({
+  encoder: val => hash(sheetId + val)
+})

--- a/compiler/src/processor.js
+++ b/compiler/src/processor.js
@@ -3,14 +3,15 @@ const nestAtRulesPlugin = require('postcss-nest-atrules')
 const nestPseudoPlugin = require('./plugins/nest-pseudo')
 const splitGroupedSelectorsPlugin = require('./plugins/split-grouped-selectors')
 const validatorPlugin = require('./plugins/validator')
+const reduceIdentsPlugin = require('./plugins/reduce-idents')
 
-const processor = postcss([
+module.exports = (css, opts = { from: undefined }, sheetId) => postcss([
   splitGroupedSelectorsPlugin,
   validatorPlugin,
   nestAtRulesPlugin,
   nestPseudoPlugin,
-])
-module.exports = (css, opts = { from: undefined }) => processor.process(css, opts)
+  reduceIdentsPlugin(sheetId),
+]).process(css, opts)
 
 const optimzr = postcss([
   /* eslint-disable import/order */

--- a/compiler/test/__snapshots__/index.test.js.snap
+++ b/compiler/test/__snapshots__/index.test.js.snap
@@ -101,3 +101,5 @@ Object {
 `;
 
 exports[`dss does not have duplicates 2`] = `".dss_14e3233-hlr2nt{display:block}"`;
+
+exports[`dss renames keyframes 1`] = `".dss_dlk2yv-1p44r6d{animation-name:qf3vqk}@keyframes qf3vqk{0%{opacity:0}100%{opacity:1}}.dss_dlk2yv-2tyosx{animation-name:f0s44}@keyframes f0s44{0%{opacity:0;margin-left:0}100%{opacity:1;margin-left:100}}"`;

--- a/compiler/test/index.test.js
+++ b/compiler/test/index.test.js
@@ -101,4 +101,25 @@ describe('dss', () => {
     expect(locals).toMatchSnapshot()
     expect(src + '\n\n⬇⬇⬇⬇\n\n' + flush()).toMatchSnapshot()
   })
+
+  it('renames keyframes', async () => {
+    const a = await dss(`
+      .a {
+        animation-name: fade;
+      }
+      @keyframes fade {0% { opacity:0 } 100% { opacity:1}}
+    `)
+    const b = await dss(`
+      .b {
+        animation-name: fade;
+      }
+      @keyframes fade {
+        0% { opacity:0; margin-left: 0; }
+        100% { opacity:1; margin-left: 100; }
+      }
+    `)
+
+    expect(a.locals.a).not.toEqual(b.locals.b)
+    expect(a.flush() + b.flush()).toMatchSnapshot()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,6 +2397,15 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -8408,6 +8417,14 @@ postcss-reduce-idents@^2.2.2:
     postcss "^5.0.4"
     postcss-value-parser "^3.0.2"
 
+postcss-reduce-idents@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-4.0.1.tgz#639115ed8014af49bb9d7d10ccb2f69167fed58a"
+  integrity sha512-A0wH7ccAoGDDOM1diWRk7jrHLMS4Ep06di2gm+y5gqblnDMMoLe+zqu4OOg4wGbX1SPRo/I20yXxEkjf/t7DBQ==
+  dependencies:
+    postcss "^7.0.0"
+    postcss-value-parser "^3.0.0"
+
 postcss-reduce-initial@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz#68f80695f045d08263a879ad240df8dd64f644ea"
@@ -8453,6 +8470,11 @@ postcss-unique-selectors@^2.0.2:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
+postcss-value-parser@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
+  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+
 postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
@@ -8489,6 +8511,15 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.16, postcss@^6.0.2
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+postcss@^7.0.0:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
+  integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -10116,6 +10147,13 @@ supports-color@^4.2.1:
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
Prevent collision of custom identifiers(e.g. keyframes) by renaming them.